### PR TITLE
Makes `llama-pack` compatible with Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,9 @@ Llama Pack is a Command Line Interface (CLI) that helps developers to create
 a Project for an Android application that launches an existing Progressive Web App (PWA) using a
 [Trusted Web Activity (TWA)](https://developers.google.com/web/updates/2019/02/using-twa).
 
-**Important:** llama-pack is still under active development. The tool works on MacOS and Linux,
-but hasn't yet been tested on Windows. It also hasn't been tested on a wide range of Web APKs,
-and bootstraping a new project may fail in those cases. Please, file issues, feature requests,
-and contribute with pull requests, if possible.
+**Important:** llama-pack is still under active development. The tool hasn't been tested on a wide
+range of Web APKs, and bootstraping a new project may fail in those cases. Please, file issues,
+feature requests, and contribute with pull requests, if possible.
 
 ## Requirements
 - [Node.js](https://nodejs.org/en/) 10.0 or above

--- a/lib/GradleWrapper.js
+++ b/lib/GradleWrapper.js
@@ -21,9 +21,17 @@ const util = require('util');
 const exec = util.promisify(require('child_process').exec);
 
 class GradleWrapper {
+  _getGradleCmd(platform) {
+    if (platform === 'win32') {
+      return 'gradlew.bat';
+    }
+    return './gradlew';
+  }
+
   async assembleRelease() {
     const env = androidSdkTools.getEnv();
-    await exec('./gradlew assembleRelease', {env: env});
+    const gradleCmd = this._getGradleCmd(process.platform);
+    await exec(`${gradleCmd} assembleRelease`, {env: env});
   }
 }
 

--- a/lib/androidSdk/AndroidSdkTools.js
+++ b/lib/androidSdk/AndroidSdkTools.js
@@ -29,11 +29,7 @@ const BUILD_TOOLS_VERSION = '29.0.2';
 class AndroidSdkTools {
   // Runs <path-to-sdk-tools>/tools/bin/sdkmanager --install "build-tools;29.0.2"
   async installBuildTools() {
-    const env = Object.assign({}, process.env);
-    env['JAVA_HOME'] = jdkInstaller.getJavaHome();
-    env['PATH'] = jdkInstaller.getJavaBin() + ':' + env['PATH'];
-    console.log(env['PATH']);
-    env['ANDROID_HOME'] = this.getAndroidHome();
+    const env = this.getEnv();
 
     console.log('Installing Build Tools');
     await util.execInteractive(

--- a/lib/jdk/JdkHelper.js
+++ b/lib/jdk/JdkHelper.js
@@ -21,9 +21,9 @@ const config = require('../Config');
 
 class JdkInstaller {
   getJavaHome() {
-    if (process.platform == 'darwin') {
+    if (process.platform === 'darwin') {
       return path.join(config.jdkPath, '/Contents/Home/');
-    } else if (process.platform == 'linux') {
+    } else if (process.platform === 'linux' || process.platform === 'win32') {
       return path.join(config.jdkPath, '/');
     }
     throw new Error(`Unsupported Platform: ${process.platform}`);
@@ -33,10 +33,26 @@ class JdkInstaller {
     return path.join(this.getJavaHome(), 'bin/');
   }
 
+  _getPathSeparator(platform) {
+    if (platform === 'win32') {
+      return ';';
+    }
+    return ':';
+  }
+
+  _getPathEnviromentKey(platform) {
+    if (platform === 'win32') {
+      return 'Path';
+    }
+    return 'PATH';
+  }
+
   getEnv() {
+    const pathSeparator = this._getPathSeparator(process.platform);
+    const pathKey = this._getPathEnviromentKey(process.platform);
     const env = Object.assign({}, process.env);
     env['JAVA_HOME'] = this.getJavaHome();
-    env['PATH'] = this.getJavaBin() + ':' + env['PATH'];
+    env[pathKey] = this.getJavaBin() + pathSeparator + env[pathKey];
     return env;
   }
 }


### PR DESCRIPTION
- Adjusts PATH and executable references to enable the CLI to run on Windows.
- Removes warning on Windows compatibility from the README