### PR TITLE
Fix import for jimp-resize

### DIFF
--- a/src/lib/TwaGenerator.js
+++ b/src/lib/TwaGenerator.js
@@ -22,7 +22,7 @@ const fetch = require('node-fetch');
 const template = require('lodash.template');
 const configure = require('@jimp/custom');
 const types = require('@jimp/types');
-const resize = require('@jimp/custom');
+const resize = require('@jimp/plugin-resize');
 const {promisify} = require('util');
 
 const Jimp = configure({


### PR DESCRIPTION
- TwaGenerator.js is using the wrong import, which causes
  initialising or updating a TWA to fail