### PR TITLE
Move distributionUrl to the bottom

### DIFF
--- a/template_project/gradle/wrapper/gradle-wrapper.properties
+++ b/template_project/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip


### PR DESCRIPTION
When you create a new Android Project from Android Studio, it on the bottom.
Just to less diffing if you come from an Android Studio project.