### PR TITLE
Update default navigationColor to black as PWAs

### DIFF
--- a/src/lib/TwaManifest.ts
+++ b/src/lib/TwaManifest.ts
@@ -204,7 +204,7 @@ export class TwaManifest {
       host: webManifestUrl.host,
       name: webManifest['short_name'] || webManifest['name'] || 'My TWA',
       themeColor: webManifest['theme_color'] || '#FFFFFF',
-      navigationColor: webManifest['theme_color'] || '#FFFFFF',
+      navigationColor: '#000000',
       backgroundColor: webManifest['background_color'] || '#FFFFFF',
       startUrl: fullStartUrl.pathname + fullStartUrl.search,
       iconUrl: icon ? new URL(icon.src, webManifestUrl).toString() : undefined,

--- a/src/spec/lib/TwaManifestSpec.ts
+++ b/src/spec/lib/TwaManifestSpec.ts
@@ -55,7 +55,7 @@ describe('TwaManifest', () => {
           .toBe('https://pwa-directory.com/favicons/android-chrome-512x512.png');
       expect(twaManifest.maskableIconUrl).toBeUndefined();
       expect(twaManifest.themeColor.hex()).toBe('#00FF00');
-      expect(twaManifest.navigationColor.hex()).toBe('#00FF00');
+      expect(twaManifest.navigationColor.hex()).toBe('#000000');
       expect(twaManifest.backgroundColor.hex()).toBe('#7CC0FF');
       expect(twaManifest.appVersion).toBe('1.0.0');
       expect(twaManifest.signingKey.path).toBe('./android.keystore');
@@ -83,7 +83,7 @@ describe('TwaManifest', () => {
       expect(twaManifest.iconUrl).toBeUndefined();
       expect(twaManifest.maskableIconUrl).toBeUndefined();
       expect(twaManifest.themeColor.hex()).toBe('#FFFFFF');
-      expect(twaManifest.navigationColor.hex()).toBe('#FFFFFF');
+      expect(twaManifest.navigationColor.hex()).toBe('#000000');
       expect(twaManifest.backgroundColor.hex()).toBe('#FFFFFF');
       expect(twaManifest.appVersion).toBe('1.0.0');
       expect(twaManifest.signingKey.path).toBe('./android.keystore');
@@ -117,7 +117,7 @@ describe('TwaManifest', () => {
         startUrl: '/',
         iconUrl: 'https://pwa-directory.com/favicons/android-chrome-512x512.png',
         themeColor: '#00ff00',
-        navigationColor: '#ff0000',
+        navigationColor: '#000000',
         backgroundColor: '#0000ff',
         appVersion: '1.0.0',
         signingKey: {


### PR DESCRIPTION
Related to https://github.com/GoogleChromeLabs/llama-pack/issues/66#issuecomment-574656372

Then, at any time the user can change the value from `twa-manifest.json` and `build.gradle`.