### PR TITLE
Escaping user input to key tool

### DIFF
--- a/src/lib/jdk/KeyTool.ts
+++ b/src/lib/jdk/KeyTool.ts
@@ -66,10 +66,10 @@ export class KeyTool {
       '-genkeypair',
       `-dname "cn=${keyOptions.fullName}, ou=${keyOptions.organizationalUnit}, ` +
           `o=${keyOptions.organization}, c=${keyOptions.country}"`,
-      `-alias ${keyOptions.alias}`,
-      `-keypass ${keyOptions.keypassword}`,
-      `-keystore ${keyOptions.path}`,
-      `-storepass ${keyOptions.password}`,
+      `-alias \"${keyOptions.alias}\"`,
+      `-keypass \"${keyOptions.keypassword}\"`,
+      `-keystore \"${keyOptions.path}\"`,
+      `-storepass \"${keyOptions.password}\"`,
       '-validity 20000',
       '-keyalg RSA',
     ];


### PR DESCRIPTION
Fixes the issue where e.g. the key password contains a hyphen.