### PR TITLE
Updates to use android-browser-helper 1.1.0

### DIFF
--- a/template_project/app/build.gradle
+++ b/template_project/app/build.gradle
@@ -159,5 +159,5 @@ preBuild.dependsOn(generateShorcutsFile)
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:1.0.0'
+    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:1.1.0'
 }

--- a/template_project/app/src/main/AndroidManifest.xml
+++ b/template_project/app/src/main/AndroidManifest.xml
@@ -78,6 +78,8 @@
             </intent-filter>
         </activity>
 
+        <activity android:name="com.google.androidbrowserhelper.trusted.FocusActivity" />
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="@string/providerAuthority"


### PR DESCRIPTION
- Uses android-browser-helper-1.1.0
- Adds FocusActivity to AndroidManifest.xml

Closes #80 