### PR TITLE
Allows automated builds

### DIFF
--- a/src/cli/cmds/build.ts
+++ b/src/cli/cmds/build.ts
@@ -32,8 +32,8 @@ interface SigningKeyPasswords {
  * Checks if the keystore password and the key password are part of the environment prompts the
  * user for a password otherwise.
  *
- * @returns {Promise<[string, string]>} A promise with a tuple where the first item is they
- * keystore password and the second is the key password.
+ * @returns {Promise<SigningKeyPasswords} the password information collected from enviromental
+ * variables or user input.
  */
 async function getPasswords(log: Log): Promise<SigningKeyPasswords> {
   // Check if passwords are set as environment variables.

--- a/src/cli/cmds/build.ts
+++ b/src/cli/cmds/build.ts
@@ -23,16 +23,21 @@ import Log from '../../lib/Log';
 import * as inquirer from 'inquirer';
 import {validatePassword} from '../inputHelpers';
 
-export async function build(config: Config, log = new Log('build')): Promise<void> {
-  const jdkHelper = new JdkHelper(process, config);
-  const androidSdkTools = new AndroidSdkTools(process, config, jdkHelper);
+/**
+ * Checks if the keystore password and the key password are part of the environment prompts the
+ * user for a password otherwise.
+ *
+ * @returns {Promise<[string, string]>} A promise with a tuple where the first item is they
+ * keystore password and the second is the key password.
+ */
+async function getPasswords(): Promise<[string, string]> {
+  // Check if passwords are set as environment variables.
+  const envKeystorePass = process.env['LLAMA_PACK_KEYSTORE_PASSWORD'];
+  const envKeyPass = process.env['LLAMA_PACK_KEY_PASSWORD'];
 
-  if (!await androidSdkTools.checkBuildTools()) {
-    console.log('Installing Android Build Tools. Please, read and accept the license agreement');
-    await androidSdkTools.installBuildTools();
+  if (envKeyPass !== undefined && envKeystorePass !== undefined) {
+    return [envKeystorePass, envKeyPass];
   }
-
-  const twaManifest = await TwaManifest.fromFile('./twa-manifest.json');
 
   // Ask user for the keystore password
   const result = await inquirer.prompt([
@@ -51,6 +56,22 @@ export async function build(config: Config, log = new Log('build')): Promise<voi
     },
   ]);
 
+  return [result.password, result.keypassword];
+}
+
+export async function build(config: Config, log = new Log('build')): Promise<void> {
+  const jdkHelper = new JdkHelper(process, config);
+  const androidSdkTools = new AndroidSdkTools(process, config, jdkHelper);
+
+  if (!await androidSdkTools.checkBuildTools()) {
+    console.log('Installing Android Build Tools. Please, read and accept the license agreement');
+    await androidSdkTools.installBuildTools();
+  }
+
+  const twaManifest = await TwaManifest.fromFile('./twa-manifest.json');
+
+  const passwords = await getPasswords();
+
   // Builds the Android Studio Project
   log.info('Building the Android App...');
   const gradleWraper = new GradleWrapper(process, androidSdkTools);
@@ -68,9 +89,9 @@ export async function build(config: Config, log = new Log('build')): Promise<voi
   const outputFile = './app-release-signed.apk';
   await androidSdkTools.apksigner(
       twaManifest.signingKey.path,
-      result.password, // keystore password
+      passwords[0], // keystore password
       twaManifest.signingKey.alias, // alias
-      result.keypassword, // key password
+      passwords[1], // key password
       './app-release-unsigned-aligned.apk', // input file path
       outputFile, // output file path
   );


### PR DESCRIPTION
- Developers can use the `LLAMA_PACK_KEYSTORE_PASSWORD` and
  `LLAMA_PACK_KEY_PASSWORD` enviroment variables to set the
  keystore and key passwords.
- When both passwords are set, they will be used instead of
  prompting the users for the passwords.

Closes #30 