### PR TITLE
Report an Error when `iconUrl` is not 200

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,13 +15,15 @@
  */
 
 import {Cli} from './cli/';
+import Log from './lib/Log';
 
 module.exports = (): void => {
   const cli = new Cli();
+  const log = new Log('cli');
   const args = process.argv.slice(2);
   cli.run(args)
       .catch((err: Error) => {
-        console.error(err.message);
+        log.error(err.message);
         process.exit(1);
       });
 };

--- a/src/lib/TwaGenerator.ts
+++ b/src/lib/TwaGenerator.ts
@@ -169,7 +169,8 @@ export class TwaGenerator {
   private async fetchIcon(iconUrl: string): Promise<Icon> {
     const response = await fetch(iconUrl);
     if (response.status !== 200) {
-      throw new Error(`Failed to download icon ${iconUrl}, with status ${response.status}`);
+      throw new Error(
+          `Failed to download icon ${iconUrl}. Responded with status ${response.status}`);
     }
     const body = await response.buffer();
     return {

--- a/src/lib/TwaGenerator.ts
+++ b/src/lib/TwaGenerator.ts
@@ -168,6 +168,9 @@ export class TwaGenerator {
    */
   private async fetchIcon(iconUrl: string): Promise<Icon> {
     const response = await fetch(iconUrl);
+    if (response.status !== 200) {
+      throw new Error(`Failed to download icon ${iconUrl}, with status ${response.status}`);
+    }
     const body = await response.buffer();
     return {
       url: iconUrl,


### PR DESCRIPTION
- When status is not 200, the generation fails with an unclear
  error message.
- Added an explicit check for the status, with a message that is
  easier to read.