### PR TITLE
`update` upgrades `versionCode` and `versionName`

### DIFF
--- a/src/cli/cmds/help.ts
+++ b/src/cli/cmds/help.ts
@@ -50,6 +50,13 @@ const HELP_MESSAGES = new Map<string, string>(
         '',
         '',
         'llama-pack update',
+        '',
+        '',
+        'Options:',
+        '--appVersionName ........... version name to be used on on the upgrade. Ignored if ' +
+            '--skipVersionUpgrade is used',
+        '--skipVersionUpgrade ....... skips upgrading appVersion and appVersionCode',
+        '--manifest ................. directory where the client should look for twa-manifest.json',
       ].join('\n')],
     ],
 );

--- a/src/cli/cmds/update.ts
+++ b/src/cli/cmds/update.ts
@@ -14,17 +14,79 @@
  *  limitations under the License.
  */
 
+import * as inquirer from 'inquirer';
 import * as path from 'path';
+import Log from '../../lib/Log';
 import {TwaGenerator} from '../../lib/TwaGenerator';
 import {TwaManifest} from '../../lib/TwaManifest';
 import {ParsedArgs} from 'minimist';
 import {APP_NAME} from '../constants';
+import {notEmpty} from '../inputHelpers';
 
+const log = new Log('update');
+
+async function updateVersions(twaManifest: TwaManifest, appVersionNameArg: string): Promise<{
+      appVersionName: string;
+      appVersionCode: number;
+    }> {
+  const previousAppVersionCode = twaManifest.appVersionCode;
+  const appVersionCode = twaManifest.appVersionCode + 1;
+
+  // If a version was passed ar parameter, use it.
+  if (appVersionNameArg) {
+    return {
+      appVersionCode: appVersionCode,
+      appVersionName: appVersionNameArg,
+    };
+  }
+
+  // Otherwise, try to upgrade automatically with the versionCode.
+  if (twaManifest.appVersionName === previousAppVersionCode.toString()) {
+    return {
+      appVersionCode: appVersionCode,
+      appVersionName: appVersionCode.toString(),
+    };
+  }
+
+  // If not not possible, ask the user to input a new version.
+  const result = await inquirer.prompt([{
+    name: 'appVersionName',
+    type: 'input',
+    message: 'versionName for the new App version:',
+    default: twaManifest.appVersionName,
+    validate: notEmpty,
+  }]);
+
+  return {
+    appVersionCode: appVersionCode,
+    appVersionName: result.appVersionName,
+  };
+}
+
+/**
+ * Updates an existing TWA Project using the `twa-manifest.json`.
+ * @param {string} [args.manifest] directory where the command should look for the
+ * `twa-manifest.json`. Defaults to the current folder.
+ * @param {boolean} [args.skipVersionUpgrade] Skips upgrading appVersionCode and appVersionName
+ * if set to true.
+ * @param {string} [args.appVersionName] Value to be used for appVersionName when upgrading
+ * versions. Ignored if `args.skipVersionUpgrade` is set to true.
+ */
 export async function update(args: ParsedArgs): Promise<void> {
   const targetDirectory = args.directory || process.cwd();
   const manifestFile = args.manifest || path.join(process.cwd(), 'twa-manifest.json');
   const twaManifest = await TwaManifest.fromFile(manifestFile);
   twaManifest.generatorApp = APP_NAME;
+
+  if (!args.skipVersionUpgrade) {
+    const newVersionInfo = await updateVersions(twaManifest, args.appVersionName);
+    twaManifest.appVersionName = newVersionInfo.appVersionName;
+    twaManifest.appVersionCode = newVersionInfo.appVersionCode;
+    log.info(`Generated new version with versionName: ${newVersionInfo.appVersionName} and ` +
+        `versionCode: ${newVersionInfo.appVersionCode}`);
+    twaManifest.saveToFile(manifestFile);
+  }
+
   const twaGenerator = new TwaGenerator();
   return await twaGenerator.createTwaProject(targetDirectory, twaManifest);
 }

--- a/src/cli/cmds/update.ts
+++ b/src/cli/cmds/update.ts
@@ -32,7 +32,7 @@ async function updateVersions(twaManifest: TwaManifest, appVersionNameArg: strin
   const previousAppVersionCode = twaManifest.appVersionCode;
   const appVersionCode = twaManifest.appVersionCode + 1;
 
-  // If a version was passed ar parameter, use it.
+  // If a version was passed as parameter, use it.
   if (appVersionNameArg) {
     return {
       appVersionCode: appVersionCode,

--- a/src/lib/TwaManifest.ts
+++ b/src/lib/TwaManifest.ts
@@ -35,7 +35,8 @@ const DEFAULT_APP_NAME = 'My TWA';
 const DEFAULT_THEME_COLOR = '#FFFFFF';
 const DEFAULT_NAVIGATION_COLOR = '#000000';
 const DEFAULT_BACKGROUND_COLOR = '#FFFFFF';
-const DEFAULT_APP_VERSION = '1.0.0';
+const DEFAULT_APP_VERSION_CODE = 1;
+const DEFAULT_APP_VERSION_NAME = DEFAULT_APP_VERSION_CODE.toString();
 const DEFAULT_SIGNING_KEY_PATH = './android.keystore';
 const DEFAULT_SIGNING_KEY_ALIAS = 'android';
 const DEFAULT_USE_BROWSER_ON_CHROMEOS = true;
@@ -131,7 +132,8 @@ export class TwaManifest {
   useBrowserOnChromeOS: boolean;
   splashScreenFadeOutDuration: number;
   signingKey: SigningKeyInfo;
-  appVersion: string;
+  appVersionCode: number;
+  appVersionName: string;
   shortcuts: string;
   generatorApp: string;
 
@@ -150,7 +152,8 @@ export class TwaManifest {
     this.useBrowserOnChromeOS = data.useBrowserOnChromeOS;
     this.splashScreenFadeOutDuration = data.splashScreenFadeOutDuration;
     this.signingKey = data.signingKey;
-    this.appVersion = data.appVersion;
+    this.appVersionName = data.appVersion;
+    this.appVersionCode = data.appVersionCode || DEFAULT_APP_VERSION_CODE;
     this.shortcuts = data.shortcuts;
     this.generatorApp = data.generatorApp || DEFAULT_GENERATOR_APP_NAME;
   }
@@ -166,6 +169,7 @@ export class TwaManifest {
       themeColor: this.themeColor.hex(),
       navigationColor: this.navigationColor.hex(),
       backgroundColor: this.backgroundColor.hex(),
+      appVersion: this.appVersionName,
     });
     await fs.promises.writeFile(filename, JSON.stringify(json, null, 2));
   }
@@ -235,7 +239,7 @@ export class TwaManifest {
       iconUrl: icon ? new URL(icon.src, webManifestUrl).toString() : undefined,
       maskableIconUrl:
          maskableIcon ? new URL(maskableIcon.src, webManifestUrl).toString() : undefined,
-      appVersion: DEFAULT_APP_VERSION,
+      appVersion: DEFAULT_APP_VERSION_NAME,
       signingKey: {
         path: DEFAULT_SIGNING_KEY_PATH,
         alias: DEFAULT_SIGNING_KEY_ALIAS,
@@ -290,7 +294,8 @@ export interface TwaManifestJson {
   useBrowserOnChromeOS: boolean;
   splashScreenFadeOutDuration: number;
   signingKey: SigningKeyInfo;
-  appVersion: string;
+  appVersionCode?: number; // Older Manifests may not have this field.
+  appVersion: string; // appVersionName - Old Manifests use `appVersion`. Keeping compatibility.
   shortcuts: string;
   generatorApp?: string;
 }

--- a/src/spec/lib/TwaManifestSpec.ts
+++ b/src/spec/lib/TwaManifestSpec.ts
@@ -55,7 +55,8 @@ describe('TwaManifest', () => {
       expect(twaManifest.themeColor.hex()).toBe('#00FF00');
       expect(twaManifest.navigationColor.hex()).toBe('#000000');
       expect(twaManifest.backgroundColor.hex()).toBe('#7CC0FF');
-      expect(twaManifest.appVersion).toBe('1.0.0');
+      expect(twaManifest.appVersionName).toBe('1');
+      expect(twaManifest.appVersionCode).toBe(1);
       expect(twaManifest.signingKey.path).toBe('./android.keystore');
       expect(twaManifest.signingKey.alias).toBe('android');
       expect(twaManifest.splashScreenFadeOutDuration).toBe(300);
@@ -84,7 +85,8 @@ describe('TwaManifest', () => {
       expect(twaManifest.themeColor.hex()).toBe('#FFFFFF');
       expect(twaManifest.navigationColor.hex()).toBe('#000000');
       expect(twaManifest.backgroundColor.hex()).toBe('#FFFFFF');
-      expect(twaManifest.appVersion).toBe('1.0.0');
+      expect(twaManifest.appVersionName).toBe('1');
+      expect(twaManifest.appVersionCode).toBe(1);
       expect(twaManifest.signingKey.path).toBe('./android.keystore');
       expect(twaManifest.signingKey.alias).toBe('android');
       expect(twaManifest.splashScreenFadeOutDuration).toBe(300);

--- a/template_project/app/build.gradle
+++ b/template_project/app/build.gradle
@@ -45,8 +45,8 @@ android {
         applicationId "<%= packageId %>"
         minSdkVersion 16
         targetSdkVersion 29
-        versionCode 1
-        versionName "1.0.0"
+        versionCode <%= appVersionCode %>
+        versionName "<%= appVersionName %>"
 
         // The name for the application
         resValue "string", "appName", twaManifest.name


### PR DESCRIPTION
- Renamed `appVersion` to `appVersionName` on `TwaManifest`.
- Added `appVersionCode` to `TwaManifest.
- Updated the template project to use `appVersionName` and
  `appVersionCode` from the TWA Manifest.
- Added new option `skipVersinUpgrade` to `update`, to regenerate
  project without updating versions.
- Added new option `appVersionName` to set a specific version name
  when updating the project
- `update` generates new versions by increasing `appVersionCode`
  by 1. When generating a new `appVersionName`, the value of
  `--appVersionName` is used if set. Otherwise, an attempt to
  generate it from the `appVersionCode` is made. If not possible,
  the user is prompted to input a version name.

Closes #74 
Closes #3