### PR TITLE
Adds web-manifest-url meta-tag and web-app-manifest.json

### DIFF
--- a/src/lib/TwaManifest.ts
+++ b/src/lib/TwaManifest.ts
@@ -39,7 +39,6 @@ const DEFAULT_APP_VERSION_CODE = 1;
 const DEFAULT_APP_VERSION_NAME = DEFAULT_APP_VERSION_CODE.toString();
 const DEFAULT_SIGNING_KEY_PATH = './android.keystore';
 const DEFAULT_SIGNING_KEY_ALIAS = 'android';
-const DEFAULT_USE_BROWSER_ON_CHROMEOS = true;
 const DEFAULT_ENABLE_NOTIFICATIONS = false;
 const DEFAULT_GENERATOR_APP_NAME = 'unknown';
 
@@ -129,13 +128,13 @@ export class TwaManifest {
   startUrl: string;
   iconUrl: string | undefined;
   maskableIconUrl: string | undefined;
-  useBrowserOnChromeOS: boolean;
   splashScreenFadeOutDuration: number;
   signingKey: SigningKeyInfo;
   appVersionCode: number;
   appVersionName: string;
   shortcuts: string;
   generatorApp: string;
+  webManifestUrl?: URL;
 
   constructor(data: TwaManifestJson) {
     this.packageId = data.packageId;
@@ -149,13 +148,13 @@ export class TwaManifest {
     this.startUrl = data.startUrl;
     this.iconUrl = data.iconUrl;
     this.maskableIconUrl = data.maskableIconUrl;
-    this.useBrowserOnChromeOS = data.useBrowserOnChromeOS;
     this.splashScreenFadeOutDuration = data.splashScreenFadeOutDuration;
     this.signingKey = data.signingKey;
     this.appVersionName = data.appVersion;
     this.appVersionCode = data.appVersionCode || DEFAULT_APP_VERSION_CODE;
     this.shortcuts = data.shortcuts;
     this.generatorApp = data.generatorApp || DEFAULT_GENERATOR_APP_NAME;
+    this.webManifestUrl = data.webManifestUrl ? new URL(data.webManifestUrl) : undefined;
   }
 
   /**
@@ -170,6 +169,7 @@ export class TwaManifest {
       navigationColor: this.navigationColor.hex(),
       backgroundColor: this.backgroundColor.hex(),
       appVersion: this.appVersionName,
+      webManifestUrl: this.webManifestUrl ? this.webManifestUrl.toString() : undefined,
     });
     await fs.promises.writeFile(filename, JSON.stringify(json, null, 2));
   }
@@ -244,10 +244,10 @@ export class TwaManifest {
         path: DEFAULT_SIGNING_KEY_PATH,
         alias: DEFAULT_SIGNING_KEY_ALIAS,
       },
-      useBrowserOnChromeOS: DEFAULT_USE_BROWSER_ON_CHROMEOS,
       splashScreenFadeOutDuration: DEFAULT_SPLASHSCREEN_FADEOUT_DURATION,
       enableNotifications: DEFAULT_ENABLE_NOTIFICATIONS,
       shortcuts: JSON.stringify(shortcuts, undefined, 2),
+      webManifestUrl: webManifestUrl.toString(),
     });
     return twaManifest;
   }
@@ -291,13 +291,13 @@ export interface TwaManifestJson {
   startUrl: string;
   iconUrl?: string;
   maskableIconUrl?: string;
-  useBrowserOnChromeOS: boolean;
   splashScreenFadeOutDuration: number;
   signingKey: SigningKeyInfo;
   appVersionCode?: number; // Older Manifests may not have this field.
   appVersion: string; // appVersionName - Old Manifests use `appVersion`. Keeping compatibility.
   shortcuts: string;
   generatorApp?: string;
+  webManifestUrl?: string;
 }
 
 export interface SigningKeyInfo {

--- a/src/spec/lib/TwaManifestSpec.ts
+++ b/src/spec/lib/TwaManifestSpec.ts
@@ -15,6 +15,7 @@
  */
 
 import {TwaManifest, TwaManifestJson} from '../../lib/TwaManifest';
+import Color = require('color');
 
 describe('TwaManifest', () => {
   describe('#fromWebManifestJson', () => {
@@ -61,6 +62,7 @@ describe('TwaManifest', () => {
       expect(twaManifest.signingKey.alias).toBe('android');
       expect(twaManifest.splashScreenFadeOutDuration).toBe(300);
       expect(twaManifest.enableNotifications).toBeFalse();
+      expect(twaManifest.webManifestUrl).toEqual(manifestUrl);
       expect(JSON.parse(twaManifest.shortcuts)).toEqual([
         {
           name: 'shortcut name',
@@ -91,6 +93,7 @@ describe('TwaManifest', () => {
       expect(twaManifest.signingKey.alias).toBe('android');
       expect(twaManifest.splashScreenFadeOutDuration).toBe(300);
       expect(twaManifest.enableNotifications).toBeFalse();
+      expect(twaManifest.webManifestUrl).toEqual(manifestUrl);
       expect(twaManifest.shortcuts).toBe('[]');
     });
 
@@ -102,6 +105,79 @@ describe('TwaManifest', () => {
       const twaManifest = TwaManifest.fromWebManifestJson(manifestUrl, manifest);
       expect(twaManifest.name).toBe('PWA Directory');
       expect(twaManifest.launcherName).toBe('PWA Directory');
+    });
+  });
+
+  describe('#constructor', () => {
+    it('Builds a TwaManifest correctly', () => {
+      const twaManifestJson = {
+        packageId: 'com.pwa_directory.twa',
+        host: 'pwa-directory.com',
+        name: 'PWA Directory',
+        launcherName: 'PwaDirectory',
+        startUrl: '/',
+        iconUrl: 'https://pwa-directory.com/favicons/android-chrome-512x512.png',
+        themeColor: '#00ff00',
+        navigationColor: '#000000',
+        backgroundColor: '#0000ff',
+        appVersion: '1.0.0',
+        appVersionCode: 10,
+        signingKey: {
+          path: './my-keystore',
+          alias: 'my-alias',
+        },
+        splashScreenFadeOutDuration: 300,
+        enableNotifications: true,
+        shortcuts: '[{name: "name", url: "/", icons: [{src: "icon.png"}]}]',
+        webManifestUrl: 'https://pwa-directory.com/manifest.json',
+        generatorApp: 'test',
+      } as TwaManifestJson;
+      const twaManifest = new TwaManifest(twaManifestJson);
+      expect(twaManifest.packageId).toEqual(twaManifestJson.packageId);
+      expect(twaManifest.host).toEqual(twaManifestJson.host);
+      expect(twaManifest.name).toEqual(twaManifestJson.name);
+      expect(twaManifest.launcherName).toEqual(twaManifest.launcherName);
+      expect(twaManifest.startUrl).toEqual(twaManifest.startUrl);
+      expect(twaManifest.iconUrl).toEqual(twaManifest.iconUrl);
+      expect(twaManifest.themeColor).toEqual(new Color('#00ff00'));
+      expect(twaManifest.navigationColor).toEqual(new Color('#000000'));
+      expect(twaManifest.backgroundColor).toEqual(new Color('#0000ff'));
+      expect(twaManifest.appVersionName).toEqual(twaManifestJson.appVersion);
+      expect(twaManifest.appVersionCode).toEqual(twaManifestJson.appVersionCode!);
+      expect(twaManifest.signingKey.path).toEqual(twaManifestJson.signingKey.path);
+      expect(twaManifest.signingKey.alias).toEqual(twaManifestJson.signingKey.alias);
+      expect(twaManifest.splashScreenFadeOutDuration)
+          .toEqual(twaManifestJson.splashScreenFadeOutDuration);
+      expect(twaManifest.enableNotifications).toEqual(twaManifestJson.enableNotifications);
+      expect(twaManifest.shortcuts).toEqual(twaManifestJson.shortcuts);
+      expect(twaManifest.webManifestUrl).toEqual(new URL(twaManifestJson.webManifestUrl!));
+      expect(twaManifest.generatorApp).toEqual(twaManifestJson.generatorApp!);
+    });
+
+    it('TwaManifest.webManifestUrl defaults to undefined', () => {
+      const twaManifestJson = {
+        packageId: 'com.pwa_directory.twa',
+        host: 'pwa-directory.com',
+        name: 'PWA Directory',
+        launcherName: 'PwaDirectory',
+        startUrl: '/',
+        iconUrl: 'https://pwa-directory.com/favicons/android-chrome-512x512.png',
+        themeColor: '#00ff00',
+        navigationColor: '#000000',
+        backgroundColor: '#0000ff',
+        appVersion: '1.0.0',
+        appVersionCode: 10,
+        signingKey: {
+          path: './my-keystore',
+          alias: 'my-alias',
+        },
+        splashScreenFadeOutDuration: 300,
+        enableNotifications: true,
+        shortcuts: '[{name: "name", url: "/", icons: [{src: "icon.png"}]}]',
+        generatorApp: 'test',
+      } as TwaManifestJson;
+      const twaManifest = new TwaManifest(twaManifestJson);
+      expect(twaManifest.webManifestUrl).toBeUndefined();
     });
   });
 

--- a/template_project/app/build.gradle
+++ b/template_project/app/build.gradle
@@ -58,10 +58,12 @@ android {
         def launchUrl = "https://" + twaManifest.hostName + twaManifest.launchUrl
         resValue "string", "launchUrl", launchUrl
 
-        // The URL that will be opened as a Desktop PWA when the TWA is installed and
-        // run on ChromeOS. This will probably give a better user experience for non-mobile
-        // devices, but will not include any native Android interaction.
-        resValue "string", "crosLaunchUrl", launchUrl
+        <% if (webManifestUrl) { %>
+            // The URL that will be opened as a Desktop PWA when the TWA is installed and
+            // run on ChromeOS. This will probably give a better user experience for non-mobile
+            // devices, but will not include any native Android interaction.
+            resValue "string", "webManifestUrl", '<%= webManifestUrl %>'
+        <% } %>
 
         // The hostname is used when building the intent-filter, so the TWA is able to
         // handle Intents to open https://svgomg.firebaseapp.com.

--- a/template_project/app/build.gradle
+++ b/template_project/app/build.gradle
@@ -59,9 +59,9 @@ android {
         resValue "string", "launchUrl", launchUrl
 
         <% if (webManifestUrl) { %>
-            // The URL that will be opened as a Desktop PWA when the TWA is installed and
-            // run on ChromeOS. This will probably give a better user experience for non-mobile
-            // devices, but will not include any native Android interaction.
+            // The URL the Web Manifest for the Progressive Web App that the TWA points to. This
+            // is used by Chrome OS to open the Web version of the PWA instead of the TWA, as it
+            // will probably give a better user experience for non-mobile devices.
             resValue "string", "webManifestUrl", '<%= webManifestUrl %>'
         <% } %>
 

--- a/template_project/app/src/main/AndroidManifest.xml
+++ b/template_project/app/src/main/AndroidManifest.xml
@@ -33,9 +33,11 @@
             android:name="asset_statements"
             android:resource="@string/assetStatements" />
 
-        <meta-data
-            android:name="cros_web_alternative"
-            android:value="@string/crosLaunchUrl" />
+        <% if (webManifestUrl) { %>
+            <meta-data
+                android:name="web_manifest_url"
+                android:value="@string/webManifestUrl" />
+        <% } %>
 
         <meta-data
             android:name="twa_generator"


### PR DESCRIPTION
- When webManifestUrl is set on twa-manifest.json, it includes a
 `web-manifest-url` meta-tag on AndroidManifest.xml with the
  correct value and creates a web-app-manifest.json at /res/raw
- When webManifestUrl ist not set, it doesn't add any meta tag

Closes #88 