### PR TITLE
Refactors TwaManifest.shortcuts

### DIFF
--- a/src/cli/cmds/init.ts
+++ b/src/cli/cmds/init.ts
@@ -89,7 +89,7 @@ async function confirmTwaConfig(twaManifest: TwaManifest): Promise<TwaManifest> 
     }, {
       name: 'shortcuts',
       type: 'confirm',
-      message: 'Include app shortcuts?\n' + twaManifest.shortcuts,
+      message: 'Include app shortcuts?\n' + JSON.stringify(twaManifest.shortcuts, null, 2),
       default: true,
     }, {
       name: 'packageId',
@@ -122,7 +122,7 @@ async function confirmTwaConfig(twaManifest: TwaManifest): Promise<TwaManifest> 
   twaManifest.startUrl = result.startUrl;
   twaManifest.iconUrl = result.iconUrl;
   twaManifest.maskableIconUrl = result.maskableIconUrl;
-  twaManifest.shortcuts = result.shortcuts ? '[]' : twaManifest.shortcuts;
+  twaManifest.shortcuts = result.shortcuts ? twaManifest.shortcuts : [];
   twaManifest.packageId = result.packageId;
   twaManifest.signingKey = {
     alias: result.keyAlias,

--- a/src/lib/TwaGenerator.ts
+++ b/src/lib/TwaGenerator.ts
@@ -19,7 +19,7 @@ import * as fs from 'fs';
 import fetch from 'node-fetch';
 import {template} from 'lodash';
 import {promisify} from 'util';
-import {TwaManifest} from './TwaManifest';
+import {TwaManifest, ShortcutInfo} from './TwaManifest';
 import Jimp = require('jimp');
 import Log from './Log';
 
@@ -232,10 +232,7 @@ export class TwaGenerator {
       await this.generateIcons(twaManifest.iconUrl, targetDirectory, IMAGES);
     }
 
-    // TODO(andreban): TwaManifest.shortcuts is a string, which is being parsed into an Object.
-    // Needs to be transformed into a proper Class.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await Promise.all(JSON.parse(twaManifest.shortcuts).map((shortcut: any, i: number) => {
+    await Promise.all(twaManifest.shortcuts.map((shortcut: ShortcutInfo, i: number) => {
       const imageDirs = SHORTCUT_IMAGES.map(
           (imageDir) => ({...imageDir, dest: `${imageDir.dest}shortcut_${i}.png`}));
       return this.generateIcons(shortcut.chosenIconUrl, targetDirectory, imageDirs);

--- a/src/lib/TwaManifest.ts
+++ b/src/lib/TwaManifest.ts
@@ -73,10 +73,6 @@ export class ShortcutInfo {
    */
   constructor(readonly name: string, readonly shortName: string, readonly url: string,
         readonly chosenIconUrl: string) {
-    this.name = name;
-    this.shortName = shortName;
-    this.url = url;
-    this.chosenIconUrl = chosenIconUrl;
   }
 }
 

--- a/src/lib/TwaManifest.ts
+++ b/src/lib/TwaManifest.ts
@@ -212,28 +212,26 @@ export class TwaManifest {
 
     const shortcuts: ShortcutInfo[] = [];
 
-    if (webManifest.shortcuts) {
-      for (const s of webManifest.shortcuts) {
-        if (!s.icons || !s.url || (!s.name && !s.short_name)) {
-          continue;
-        }
+    for (const s of webManifest.shortcuts || []) {
+      if (!s.icons || !s.url || (!s.name && !s.short_name)) {
+        continue;
+      }
 
-        const suitableIcon = util.findSuitableIcon(s.icons, 'any');
-        if (!suitableIcon) {
-          continue;
-        }
+      const suitableIcon = util.findSuitableIcon(s.icons, 'any');
+      if (!suitableIcon) {
+        continue;
+      }
 
-        const name = s.name || s.short_name;
-        const shortName = s.short_name || s.name!.substring(0, SHORT_NAME_MAX_SIZE);
-        const url = new URL(s.url, webManifestUrl).toString();
-        const iconUrl = new URL(suitableIcon.src, webManifestUrl).toString();
-        const shortcutInfo = new ShortcutInfo(name!, shortName!, url, iconUrl);
+      const name = s.name || s.short_name;
+      const shortName = s.short_name || s.name!.substring(0, SHORT_NAME_MAX_SIZE);
+      const url = new URL(s.url, webManifestUrl).toString();
+      const iconUrl = new URL(suitableIcon.src, webManifestUrl).toString();
+      const shortcutInfo = new ShortcutInfo(name!, shortName!, url, iconUrl);
 
-        shortcuts.push(shortcutInfo);
+      shortcuts.push(shortcutInfo);
 
-        if (shortcuts.length === 3) {
-          break;
-        }
+      if (shortcuts.length === 4) {
+        break;
       }
     }
 

--- a/src/lib/TwaManifest.ts
+++ b/src/lib/TwaManifest.ts
@@ -29,6 +29,9 @@ const DISALLOWED_ANDROID_PACKAGE_CHARS_REGEX = /[^ a-zA-Z0-9_\.]/;
 // The minimum size needed for the app icon.
 const MIN_ICON_SIZE = 512;
 
+// As described on https://developer.chrome.com/apps/manifest/name#short_name
+const SHORT_NAME_MAX_SIZE = 12;
+
 // Default values used on the Twa Manifest
 const DEFAULT_SPLASHSCREEN_FADEOUT_DURATION = 300;
 const DEFAULT_APP_NAME = 'My TWA';
@@ -221,7 +224,7 @@ export class TwaManifest {
         }
 
         const name = s.name || s.short_name;
-        const shortName = s.short_name || s.name!.substring(0, 12);
+        const shortName = s.short_name || s.name!.substring(0, SHORT_NAME_MAX_SIZE);
         const url = new URL(s.url, webManifestUrl).toString();
         const iconUrl = new URL(suitableIcon.src, webManifestUrl).toString();
         const shortcutInfo = new ShortcutInfo(name!, shortName!, url, iconUrl);
@@ -238,8 +241,8 @@ export class TwaManifest {
       packageId: generatePackageId(webManifestUrl.host),
       host: webManifestUrl.host,
       name: webManifest['name'] || webManifest['short_name'] || DEFAULT_APP_NAME,
-      launcherName:
-          webManifest['short_name'] || webManifest['name']?.substring(0, 12) || DEFAULT_APP_NAME,
+      launcherName: webManifest['short_name'] ||
+          webManifest['name']?.substring(0, SHORT_NAME_MAX_SIZE) || DEFAULT_APP_NAME,
       themeColor: webManifest['theme_color'] || DEFAULT_THEME_COLOR,
       navigationColor: DEFAULT_NAVIGATION_COLOR,
       backgroundColor: webManifest['background_color'] || DEFAULT_BACKGROUND_COLOR,

--- a/src/spec/lib/TwaManifestSpec.ts
+++ b/src/spec/lib/TwaManifestSpec.ts
@@ -63,14 +63,15 @@ describe('TwaManifest', () => {
       expect(twaManifest.splashScreenFadeOutDuration).toBe(300);
       expect(twaManifest.enableNotifications).toBeFalse();
       expect(twaManifest.webManifestUrl).toEqual(manifestUrl);
-      expect(JSON.parse(twaManifest.shortcuts)).toEqual([
-        {
-          name: 'shortcut name',
-          shortName: 'short',
-          url: 'https://pwa-directory.com/launch',
-          chosenIconUrl: 'https://pwa-directory.com/shortcut_icon.png',
-        },
-      ]);
+      expect(twaManifest.shortcuts.length).toBe(1);
+      expect(twaManifest.shortcuts[0].name).toBe('shortcut name');
+      expect(twaManifest.shortcuts[0].shortName).toBe('short');
+      expect(twaManifest.shortcuts[0].url).toBe('https://pwa-directory.com/launch');
+      expect(twaManifest.shortcuts[0].chosenIconUrl)
+          .toBe('https://pwa-directory.com/shortcut_icon.png');
+      expect(twaManifest.generateShortcuts())
+          .toBe('[[name:\'shortcut name\', short_name:\'short\',' +
+            ' url:\'https://pwa-directory.com/launch\', icon:\'shortcut_0\']]');
     });
 
     it('Sets correct defaults for unavailable fields', () => {
@@ -94,7 +95,8 @@ describe('TwaManifest', () => {
       expect(twaManifest.splashScreenFadeOutDuration).toBe(300);
       expect(twaManifest.enableNotifications).toBeFalse();
       expect(twaManifest.webManifestUrl).toEqual(manifestUrl);
-      expect(twaManifest.shortcuts).toBe('[]');
+      expect(twaManifest.shortcuts).toEqual([]);
+      expect(twaManifest.generateShortcuts()).toBe('[]');
     });
 
     it('Uses "name" when "short_name" is not available', () => {
@@ -104,7 +106,7 @@ describe('TwaManifest', () => {
       const manifestUrl = new URL('https://pwa-directory.com/manifest.json');
       const twaManifest = TwaManifest.fromWebManifestJson(manifestUrl, manifest);
       expect(twaManifest.name).toBe('PWA Directory');
-      expect(twaManifest.launcherName).toBe('PWA Directory');
+      expect(twaManifest.launcherName).toBe('PWA Director');
     });
   });
 
@@ -128,7 +130,7 @@ describe('TwaManifest', () => {
         },
         splashScreenFadeOutDuration: 300,
         enableNotifications: true,
-        shortcuts: '[{name: "name", url: "/", icons: [{src: "icon.png"}]}]',
+        shortcuts: [{name: 'name', shortName: 'shortName', url: '/', chosenIconUrl: 'icon.png'}],
         webManifestUrl: 'https://pwa-directory.com/manifest.json',
         generatorApp: 'test',
       } as TwaManifestJson;
@@ -173,7 +175,7 @@ describe('TwaManifest', () => {
         },
         splashScreenFadeOutDuration: 300,
         enableNotifications: true,
-        shortcuts: '[{name: "name", url: "/", icons: [{src: "icon.png"}]}]',
+        shortcuts: [{name: 'name', url: '/', chosenIconUrl: 'icon.png'}],
         generatorApp: 'test',
       } as TwaManifestJson;
       const twaManifest = new TwaManifest(twaManifestJson);
@@ -205,7 +207,7 @@ describe('TwaManifest', () => {
         },
         splashScreenFadeOutDuration: 300,
         enableNotifications: true,
-        shortcuts: '[{name: "name", url: "/", icons: [{src: "icon.png"}]}]',
+        shortcuts: [{name: 'name', url: '/', chosenIconUrl: 'icon.png'}],
       } as TwaManifestJson);
       expect(twaManifest.validate()).toBeTrue();
     });

--- a/template_project/app/build.gradle
+++ b/template_project/app/build.gradle
@@ -148,7 +148,7 @@ task generateShorcutsFile {
                     'intent'(
                             'android:action': 'android.intent.action.MAIN',
                             'android:targetPackage': twaManifest.applicationId,
-                            'android:targetClass': 'android.support.customtabs.trusted.LauncherActivity',
+                            'android:targetClass': 'com.google.androidbrowserhelper.trusted.LauncherActivity',
                             'android:data': s.url)
                     'categories'('android:name': 'android.intent.category.LAUNCHER')
                 }


### PR DESCRIPTION
- Change `TwaManifest.shortcuts` to be `ShortcutInfo[]` instead
  of `string`.
- Refactor code to reflect that change
- Fixes reversed if condition in `init` leading to not adding
  shortcuts.
- Test the result of `generateShortcut()`
- Uses correct `LauncherActivity` in `build.gradle`
- Truncates `short_name` to 12 characters, when unavailable and copying from `name`. Recommendation for 12 chars [here](https://developer.chrome.com/apps/manifest/name#short_name)