### PR TITLE
Fixes handling of maskable images

### DIFF
--- a/packages/cli/src/lib/cmds/init.ts
+++ b/packages/cli/src/lib/cmds/init.ts
@@ -79,7 +79,7 @@ async function confirmTwaConfig(twaManifest: TwaManifest): Promise<TwaManifest> 
       message: 'URL to an image that is at least 512x512px to be used when generating ' +
           'maskable icons',
       default: twaManifest.maskableIconUrl,
-      filter: (input): string | undefined => input.length === 0 ? undefined : input.length,
+      filter: (input): string | undefined => input.length === 0 ? undefined : input,
       validate: (input): boolean => input === undefined || validateUrl(input),
     }, {
       name: 'shortcuts',

--- a/packages/core/src/lib/TwaGenerator.ts
+++ b/packages/core/src/lib/TwaGenerator.ts
@@ -201,6 +201,13 @@ export class TwaGenerator {
           ` Responded with Content-Type "${contentType}"`);
     }
 
+    // TODO(andreban): Support for image/svg being tracked in
+    // https://github.com/GoogleChromeLabs/llama-pack/issues/103
+    if (contentType.startsWith('image/svg')) {
+      throw new Error(`Received icon "${iconUrl}" with Content-Type "${contentType}",` +
+       ' which is not currently supported');
+    }
+
     const body = await response.buffer();
     return {
       url: iconUrl,

--- a/packages/core/src/lib/TwaGenerator.ts
+++ b/packages/core/src/lib/TwaGenerator.ts
@@ -194,6 +194,13 @@ export class TwaGenerator {
       throw new Error(
           `Failed to download icon ${iconUrl}. Responded with status ${response.status}`);
     }
+
+    const contentType = response.headers.get('content-type');
+    if (!contentType?.startsWith('image/')) {
+      throw new Error(`Received icon "${iconUrl}" with invalid Content-Type.` +
+          ` Responded with Content-Type "${contentType}"`);
+    }
+
     const body = await response.buffer();
     return {
       url: iconUrl,


### PR DESCRIPTION
- [cli] Fixes validation for maskable images
- [core] Checks for content-type when downloading images and
  throws an error when the content-type is invalid.