### PR TITLE
Move Config read/write into cli

### DIFF
--- a/packages/cli/src/lib/Cli.ts
+++ b/packages/cli/src/lib/Cli.ts
@@ -15,15 +15,15 @@
  */
 
 import * as minimist from 'minimist';
-import {Config} from '@llama-pack/core';
 import {update} from './cmds/update';
 import {help} from './cmds/help';
 import {build} from './cmds/build';
 import {init} from './cmds/init';
+import {loadOrCreateConfig} from './config';
 
 export class Cli {
   async run(args: string[]): Promise<void> {
-    const config = await Config.loadOrCreate();
+    const config = await loadOrCreateConfig();
 
     const parsedArgs = minimist(args);
     const command = args[0] || 'help';

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import {existsSync} from 'fs';
+import {join} from 'path';
+import {homedir} from 'os';
+import {Config} from '@llama-pack/core';
+import * as inquirer from 'inquirer';
+
+const DEFAULT_CONFIG_PATH = join(homedir(), '/.llama-pack/llama-pack-config.json');
+
+async function createConfig(): Promise<Config> {
+  const result = await inquirer.prompt([
+    {
+      name: 'jdkPath',
+      message: 'Path to the JDK:',
+      validate: existsSync,
+    }, {
+      name: 'androidSdkPath',
+      message: 'Path to the Android SDK:',
+      validate: existsSync,
+    },
+  ]);
+  return new Config(result.jdkPath, result.androidSdkPath);
+}
+
+export async function loadOrCreateConfig(path = DEFAULT_CONFIG_PATH): Promise<Config> {
+  const existingConfig = await Config.loadConfig(path);
+  if (existingConfig) return existingConfig;
+
+  const config = await createConfig();
+  await config.saveConfig(path);
+  return config;
+}

--- a/packages/core/src/lib/Config.ts
+++ b/packages/core/src/lib/Config.ts
@@ -14,19 +14,11 @@
  *  limitations under the License.
  */
 
-import {promisify} from 'util';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
-import * as inquirer from 'inquirer';
-
-const homedir = os.homedir();
-const fileExists = promisify(fs.exists);
-
-const CONFIG_FILE_NAME = path.join(homedir, '/.llama-pack/llama-pack-config.json');
+import {promises as fs} from 'fs';
+import {dirname} from 'path';
 
 export class Config {
-  jdkPath: string ;
+  jdkPath: string;
   androidSdkPath: string;
 
   constructor(jdkPath: string, androidSdkPath: string) {
@@ -34,48 +26,28 @@ export class Config {
     this.androidSdkPath = androidSdkPath;
   }
 
-  async saveConfig(): Promise<void> {
-    await fs.promises.mkdir(path.join(homedir, '/.llama-pack'), {recursive: true});
-    await fs.promises.writeFile(CONFIG_FILE_NAME, JSON.stringify(this));
+  serialize(): string {
+    return JSON.stringify(this);
   }
 
-  async check(): Promise<void> {
-    if (!await fileExists(this.jdkPath)) {
-      throw new Error(`${this.jdkPath} does not exist. Check the jdkPath on your config`);
-    }
-    if (!await fileExists(this.androidSdkPath)) {
-      throw new Error(
-          `${this.androidSdkPath} does not exist. Check the androidSdkPath on your config`);
-    };
+  async saveConfig(path: string): Promise<void> {
+    await fs.mkdir(dirname(path), {recursive: true});
+    await fs.writeFile(path, this.serialize());
   }
 
-  static async createConfig(): Promise<Config> {
-    // TODO(andreban): Move this prompt from '/lib' to '/cli'.
-    const result = await inquirer.prompt([
-      {
-        name: 'jdkPath',
-        message: 'Path to the JDK:',
-        validate: fs.existsSync,
-      }, {
-        name: 'androidSdkPath',
-        message: 'Path to the Android SDK:',
-        validate: fs.existsSync,
-      },
-    ]);
-    return new Config(result.jdkPath, result.androidSdkPath);
-  }
-
-  static async loadConfig(): Promise<Config> {
-    const config = JSON.parse((await fs.promises.readFile(CONFIG_FILE_NAME)).toString());
+  static deserialize(data: string): Config {
+    const config = JSON.parse(data);
     return new Config(config.jdkPath, config.androidSdkPath);
   }
 
-  static async loadOrCreate(): Promise<Config> {
-    if (await fileExists(CONFIG_FILE_NAME)) {
-      return await Config.loadConfig();
+  static async loadConfig(path: string): Promise<Config | undefined> {
+    try {
+      const data = await fs.readFile(path, 'utf8');
+      return Config.deserialize(data);
+    } catch (err) {
+      // If config file does not exist
+      if (err.code === 'ENOENT') return undefined;
+      throw err;
     }
-    const config = await Config.createConfig();
-    await config.saveConfig();
-    return config;
   }
 }


### PR DESCRIPTION
Moves functions for reading/writing Config into the cli, since none of them are used in core. check() has been removed since its no longer used.

Also added a `path` parameter so a prompt could be added to allow custom config paths.

Core Config is now just a data class, so perhaps it should be changed to an interface.