### PR TITLE
Adaptative Icons Improvements

### DIFF
--- a/packages/core/template_project/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/packages/core/template_project/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -15,10 +15,11 @@
 -->
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:aapt="http://schemas.android.com/aapt">
-    <background>
+    <background android:drawable="@android:color/white" />
+    <foreground>
         <aapt:attr name="android:drawable">
             <layer-list>
-                <item android:drawable="@android:color/black" />
+                <item android:drawable="@android:color/white" />
                 <item android:drawable="@mipmap/ic_maskable"
 					android:top="12.75dp"
 					android:right="12.75dp"
@@ -26,6 +27,5 @@
 					android:bottom="12.75dp" />
             </layer-list>
         </aapt:attr>
-    </background>
-    <foreground android:drawable="@android:color/transparent" />
+    </foreground>
 </adaptive-icon>

--- a/packages/core/template_project/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/packages/core/template_project/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -15,8 +15,7 @@
 -->
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:aapt="http://schemas.android.com/aapt">
-    <background android:drawable="@android:color/white" />
-    <foreground>
+    <background>
         <aapt:attr name="android:drawable">
             <layer-list>
                 <item android:drawable="@android:color/white" />
@@ -27,5 +26,6 @@
 					android:bottom="12.75dp" />
             </layer-list>
         </aapt:attr>
-    </foreground>
+    </background>
+    <foreground android:drawable="@android:color/transparent" />
 </adaptive-icon>

--- a/packages/core/template_project/gradle.properties
+++ b/packages/core/template_project/gradle.properties
@@ -11,5 +11,4 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-
-
+android.useAndroidX=true


### PR DESCRIPTION
- Background for transparent icons is white.
- ~~Moves icon to the foreground layer, instead of background.~~
- Adds `android.useAndroidX=true` to `build.gradle` to make importing the project into Android Studio more seamless (unrelated to the icon).

Closes #112
