### PR TITLE
Increases minSdkVersion to 19

### DIFF
--- a/packages/core/template_project/app/build.gradle
+++ b/packages/core/template_project/app/build.gradle
@@ -43,7 +43,7 @@ android {
     compileSdkVersion 29
     defaultConfig {
         applicationId "<%= packageId %>"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 29
         versionCode <%= appVersionCode %>
         versionName "<%= appVersionName %>"


### PR DESCRIPTION
- Recent versions of Chrome only run on Android 4.4, KitKat
  (API level 19) and above.
- Even with the planned WebView fallback, up to android 5.0,
  Lollipop (API Level 22), the WebView wasn't updatable via
  the Play Store and is unlikely to render modern Web Apps
  correctly.
- The Android dashboard (https://developer.android.com/about/dashboards)
  points to API level 16 to 19 accounting for 3.2% of users.